### PR TITLE
Заглушки контроллеров

### DIFF
--- a/bot/pom.xml
+++ b/bot/pom.xml
@@ -165,6 +165,52 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>7.3.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-controller</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/api.json</inputSpec>
+                            <generatorName>spring</generatorName>
+                            <apiPackage>edu.java.bot.controllers</apiPackage>
+                            <modelPackage>edu.java.bot.controllers.model</modelPackage>
+                            <configOptions>
+                                <useSpringBoot3>true</useSpringBoot3>
+                                <interfaceOnly>true</interfaceOnly>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-client-for-scrapper</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/../scrapper/src/main/resources/api.json</inputSpec>
+                            <generatorName>java</generatorName>
+                            <packageName>edu.java.bot.clients.common.openapi</packageName>
+                            <apiPackage>edu.java.bot.clients.scrapper</apiPackage>
+                            <modelPackage>edu.java.bot.clients.scrapper.model</modelPackage>
+                            <invokerPackage>edu.java.bot.clients.common.openapi.invoker</invokerPackage>
+                            <generateModelTests>false</generateModelTests>
+                            <generateModelDocumentation>false</generateModelDocumentation>
+                            <generateApiTests>false</generateApiTests>
+                            <generateApiDocumentation>false</generateApiDocumentation>
+                            <configOptions>
+                                <generateClientAsBean>true</generateClientAsBean>
+                                <library>webclient</library>
+                                <useJakartaEe>true</useJakartaEe>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/bot/pom.xml
+++ b/bot/pom.xml
@@ -203,7 +203,6 @@
                             <generateApiTests>false</generateApiTests>
                             <generateApiDocumentation>false</generateApiDocumentation>
                             <configOptions>
-                                <generateClientAsBean>true</generateClientAsBean>
                                 <library>webclient</library>
                                 <useJakartaEe>true</useJakartaEe>
                             </configOptions>

--- a/bot/src/main/java/edu/java/bot/BotApplication.java
+++ b/bot/src/main/java/edu/java/bot/BotApplication.java
@@ -16,6 +16,6 @@ public class BotApplication {
 
     @Bean
     public TelegramBot telegramBot(ApplicationConfig applicationConfig) {
-        return new TelegramBot(applicationConfig.telegramToken);
+        return new TelegramBot(applicationConfig.getTelegramToken());
     }
 }

--- a/bot/src/main/java/edu/java/bot/BotApplication.java
+++ b/bot/src/main/java/edu/java/bot/BotApplication.java
@@ -15,8 +15,7 @@ public class BotApplication {
     }
 
     @Bean
-    public TelegramBot telegramBot(ApplicationConfig config) {
-        return new TelegramBot(config.telegramToken());
+    public TelegramBot telegramBot(ApplicationConfig applicationConfig) {
+        return new TelegramBot(applicationConfig.telegramToken);
     }
-
 }

--- a/bot/src/main/java/edu/java/bot/clients/scrapper/ScrapperClientConfiguration.java
+++ b/bot/src/main/java/edu/java/bot/clients/scrapper/ScrapperClientConfiguration.java
@@ -1,0 +1,19 @@
+package edu.java.bot.clients.scrapper;
+
+import edu.java.bot.clients.common.openapi.invoker.ApiClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ScrapperClientConfiguration {
+    @Value("#{@applicationConfig.clients.scrapper.baseUrl}")
+    public String baseUrl;
+
+    @Bean
+    DefaultApi scrapperClient() {
+        ApiClient apiClient = new ApiClient();
+        apiClient.setBasePath(baseUrl);
+        return new DefaultApi(apiClient);
+    }
+}

--- a/bot/src/main/java/edu/java/bot/clients/scrapper/ScrapperClientConfiguration.java
+++ b/bot/src/main/java/edu/java/bot/clients/scrapper/ScrapperClientConfiguration.java
@@ -11,9 +11,9 @@ public class ScrapperClientConfiguration {
     public String baseUrl;
 
     @Bean
-    DefaultApi scrapperClient() {
+    ScrapperApi scrapperClient() {
         ApiClient apiClient = new ApiClient();
         apiClient.setBasePath(baseUrl);
-        return new DefaultApi(apiClient);
+        return new ScrapperApi(apiClient);
     }
 }

--- a/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
+++ b/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
@@ -11,16 +11,16 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "app", ignoreUnknownFields = false)
 public class ApplicationConfig {
     @NotEmpty
-    public String telegramToken;
+    String telegramToken;
 
     @NotNull
-    public Clients clients = new Clients();
+    Clients clients = new Clients();
 
     public String getTelegramToken() {
         return telegramToken;
     }
 
-    public void setTelegramToken(String telegramToken) {
+    void setTelegramToken(String telegramToken) {
         this.telegramToken = telegramToken;
     }
 
@@ -28,7 +28,7 @@ public class ApplicationConfig {
         return clients;
     }
 
-    public void setClients(Clients clients) {
+    void setClients(Clients clients) {
         this.clients = clients;
     }
 }

--- a/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
+++ b/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
@@ -1,13 +1,34 @@
 package edu.java.bot.configuration;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
 @Validated
+@Component
 @ConfigurationProperties(prefix = "app", ignoreUnknownFields = false)
-public record ApplicationConfig(
+public class ApplicationConfig {
     @NotEmpty
-    String telegramToken
-) {
+    public String telegramToken;
+
+    @NotNull
+    public Clients clients = new Clients();
+
+    public String getTelegramToken() {
+        return telegramToken;
+    }
+
+    public void setTelegramToken(String telegramToken) {
+        this.telegramToken = telegramToken;
+    }
+
+    public Clients getClients() {
+        return clients;
+    }
+
+    public void setClients(Clients clients) {
+        this.clients = clients;
+    }
 }

--- a/bot/src/main/java/edu/java/bot/configuration/Clients.java
+++ b/bot/src/main/java/edu/java/bot/configuration/Clients.java
@@ -1,0 +1,13 @@
+package edu.java.bot.configuration;
+
+public class Clients {
+    public ScrapperClient scrapper = new ScrapperClient();
+
+    public ScrapperClient getScrapper() {
+        return scrapper;
+    }
+
+    public void setScrapper(ScrapperClient scrapper) {
+        this.scrapper = scrapper;
+    }
+}

--- a/bot/src/main/java/edu/java/bot/configuration/Clients.java
+++ b/bot/src/main/java/edu/java/bot/configuration/Clients.java
@@ -1,13 +1,13 @@
 package edu.java.bot.configuration;
 
 public class Clients {
-    public ScrapperClient scrapper = new ScrapperClient();
+    ScrapperClient scrapper = new ScrapperClient();
 
     public ScrapperClient getScrapper() {
         return scrapper;
     }
 
-    public void setScrapper(ScrapperClient scrapper) {
+    void setScrapper(ScrapperClient scrapper) {
         this.scrapper = scrapper;
     }
 }

--- a/bot/src/main/java/edu/java/bot/configuration/ScrapperClient.java
+++ b/bot/src/main/java/edu/java/bot/configuration/ScrapperClient.java
@@ -1,0 +1,13 @@
+package edu.java.bot.configuration;
+
+public class ScrapperClient {
+    public String baseUrl = "http://localhost:8080/";
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+}

--- a/bot/src/main/java/edu/java/bot/configuration/ScrapperClient.java
+++ b/bot/src/main/java/edu/java/bot/configuration/ScrapperClient.java
@@ -1,13 +1,13 @@
 package edu.java.bot.configuration;
 
 public class ScrapperClient {
-    public String baseUrl = "http://localhost:8080/";
+    String baseUrl = "http://localhost:8080/";
 
     public String getBaseUrl() {
         return baseUrl;
     }
 
-    public void setBaseUrl(String baseUrl) {
+    void setBaseUrl(String baseUrl) {
         this.baseUrl = baseUrl;
     }
 }

--- a/bot/src/main/java/edu/java/bot/controllers/RestExceptionHandler.java
+++ b/bot/src/main/java/edu/java/bot/controllers/RestExceptionHandler.java
@@ -1,0 +1,64 @@
+package edu.java.bot.controllers;
+
+import edu.java.bot.controllers.model.ApiErrorResponse;
+import java.util.Arrays;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class RestExceptionHandler {
+    @ExceptionHandler
+    public ResponseEntity<ApiErrorResponse> handleException(Exception e) {
+        ApiErrorResponse response = new ApiErrorResponse();
+
+        if (e instanceof ErrorResponse errorResponse) {
+            fillResponseFromErrorResponse(response, errorResponse);
+        }
+        fillResponseFromException(response, e);
+
+        HttpStatus responseCode;
+        try {
+            responseCode = HttpStatus.valueOf(Integer.parseInt(response.getCode()));
+        } catch (IllegalArgumentException exception) {
+            responseCode = HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        return new ResponseEntity<>(response, responseCode);
+    }
+
+    public static void fillResponseFromErrorResponse(ApiErrorResponse response, ErrorResponse e) {
+        if (response.getCode() == null) {
+            response.setCode(Integer.toString(e.getBody().getStatus()));
+        }
+        if (response.getDescription() == null) {
+            response.setDescription(e.getBody().getDetail());
+        }
+    }
+
+    public static void fillResponseFromException(ApiErrorResponse response, Exception e) {
+        if (response.getCode() == null) {
+            if (e instanceof HttpMessageNotReadableException) {
+                response.setCode("400");
+            } else {
+                response.setCode("500");
+            }
+        }
+        if (response.getExceptionName() == null) {
+            response.setExceptionName(e.getClass().getSimpleName());
+        }
+        if (response.getExceptionMessage() == null) {
+            response.setExceptionMessage(e.getMessage());
+        }
+        if (response.getDescription() == null) {
+            response.setDescription(e.toString());
+        }
+        if (response.getStacktrace() == null) {
+            response.setStacktrace(
+                Arrays.stream(e.getStackTrace()).map(StackTraceElement::toString).toList()
+            );
+        }
+    }
+}

--- a/bot/src/main/java/edu/java/bot/controllers/UpdatesApiController.java
+++ b/bot/src/main/java/edu/java/bot/controllers/UpdatesApiController.java
@@ -1,0 +1,16 @@
+package edu.java.bot.controllers;
+
+import edu.java.bot.controllers.model.LinkUpdate;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Log4j2
+public class UpdatesApiController implements UpdatesApi {
+    @Override
+    public ResponseEntity<Void> updatesPost(LinkUpdate linkUpdate) {
+        log.trace("updatesPost: " + linkUpdate);
+        return UpdatesApi.super.updatesPost(linkUpdate);
+    }
+}

--- a/bot/src/main/resources/api.json
+++ b/bot/src/main/resources/api.json
@@ -1,0 +1,93 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Bot API",
+        "version": "1.0.0",
+        "contact": {
+            "name": "Alexander Biryukov",
+            "url": "https://github.com"
+        }
+    },
+    "paths": {
+        "/updates": {
+            "post": {
+                "summary": "Отправить обновление",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/LinkUpdate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Обновление обработано"
+                    },
+                    "400": {
+                        "description": "Некорректные параметры запроса",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "ApiErrorResponse": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "code": {
+                        "type": "string"
+                    },
+                    "exceptionName": {
+                        "type": "string"
+                    },
+                    "exceptionMessage": {
+                        "type": "string"
+                    },
+                    "stacktrace": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "LinkUpdate": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "url": {
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "tgChatIds": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bot/src/main/resources/api.json
+++ b/bot/src/main/resources/api.json
@@ -63,7 +63,11 @@
                             "type": "string"
                         }
                     }
-                }
+                },
+                "required": [
+                    "code",
+                    "description"
+                ]
             },
             "LinkUpdate": {
                 "type": "object",
@@ -86,7 +90,11 @@
                             "format": "int64"
                         }
                     }
-                }
+                },
+                "required": [
+                    "url",
+                    "tgChatIds"
+                ]
             }
         }
     }

--- a/bot/src/main/resources/api.json
+++ b/bot/src/main/resources/api.json
@@ -11,6 +11,7 @@
     "paths": {
         "/updates": {
             "post": {
+                "tags": [ "bot" ],
                 "summary": "Отправить обновление",
                 "requestBody": {
                     "content": {

--- a/bot/src/main/resources/application.yml
+++ b/bot/src/main/resources/application.yml
@@ -12,3 +12,7 @@ server:
 
 logging:
   config: classpath:log4j2-plain.xml
+
+springdoc:
+  swagger-ui:
+    path: "/swagger-ui"

--- a/bot/src/test/java/edu/java/bot/RestExceptionHandlerTest.java
+++ b/bot/src/test/java/edu/java/bot/RestExceptionHandlerTest.java
@@ -1,0 +1,91 @@
+package edu.java.bot;
+
+import edu.java.bot.controllers.model.ApiErrorResponse;
+import java.net.URI;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class RestExceptionHandlerTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    @Test
+    void testUnknownEndpoint() {
+        ResponseEntity<ApiErrorResponse> response =
+            restTemplate.getForEntity(URI.create("http://localhost:" + port + "/"), ApiErrorResponse.class);
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        Assertions.assertEquals(HttpStatus.NOT_FOUND.value(), Integer.valueOf(response.getBody().getCode()));
+    }
+
+    @Test
+    void testMethodNotSupported() {
+        ResponseEntity<ApiErrorResponse> response =
+            restTemplate.getForEntity(URI.create("http://localhost:" + port + "/updates"), ApiErrorResponse.class);
+
+        Assertions.assertEquals(HttpStatus.METHOD_NOT_ALLOWED, response.getStatusCode());
+        Assertions.assertEquals(HttpStatus.METHOD_NOT_ALLOWED.value(), Integer.valueOf(response.getBody().getCode()));
+    }
+
+    @Test
+    void testNoPayload() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> entity = new HttpEntity<>("", headers);
+
+        ResponseEntity<ApiErrorResponse> response = restTemplate.exchange(
+            URI.create("http://localhost:" + port + "/updates"),
+            HttpMethod.POST,
+            entity,
+            ApiErrorResponse.class
+        );
+
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        Assertions.assertEquals(
+            HttpStatus.BAD_REQUEST.value(),
+            Integer.valueOf(response.getBody().getCode())
+        );
+        Assertions.assertTrue(response.getBody().getDescription().contains("request body is missing"));
+    }
+
+    @Test
+    void testInvalidPayload() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> entity = new HttpEntity<>(
+            """
+            {
+                "id": 123,
+                "tgChatIds": []
+            }
+            """,
+            headers
+        );
+
+        ResponseEntity<ApiErrorResponse> response = restTemplate.exchange(
+            URI.create("http://localhost:" + port + "/updates"),
+            HttpMethod.POST,
+            entity,
+            ApiErrorResponse.class
+        );
+
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST.value(), Integer.valueOf(response.getBody().getCode()));
+        Assertions.assertTrue(response.getBody().getDescription().contains("Invalid request content"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,25 @@
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Openapi generated code -->
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.2.6</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-core -->
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-core</artifactId>
+            <version>2.2.20</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-models -->
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-models</artifactId>
+            <version>2.2.20</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,20 @@
             <artifactId>swagger-models</artifactId>
             <version>2.2.20</version>
         </dependency>
+
+        <!-- Spring Doc, swagger-ui, etc -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/scrapper/pom.xml
+++ b/scrapper/pom.xml
@@ -151,6 +151,52 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>7.3.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-controller</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/api.json</inputSpec>
+                            <generatorName>spring</generatorName>
+                            <apiPackage>edu.java.scrapper.controllers</apiPackage>
+                            <modelPackage>edu.java.scrapper.controllers.model</modelPackage>
+                            <configOptions>
+                                <useSpringBoot3>true</useSpringBoot3>
+                                <interfaceOnly>true</interfaceOnly>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-client-for-bot</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/../bot/src/main/resources/api.json</inputSpec>
+                            <generatorName>java</generatorName>
+                            <packageName>edu.java.scrapper.clients.common.openapi</packageName>
+                            <apiPackage>edu.java.scrapper.clients.scrapper</apiPackage>
+                            <modelPackage>edu.java.scrapper.clients.scrapper.model</modelPackage>
+                            <invokerPackage>edu.java.scrapper.clients.common.openapi.invoker</invokerPackage>
+                            <generateModelTests>false</generateModelTests>
+                            <generateModelDocumentation>false</generateModelDocumentation>
+                            <generateApiTests>false</generateApiTests>
+                            <generateApiDocumentation>false</generateApiDocumentation>
+                            <configOptions>
+                                <generateClientAsBean>true</generateClientAsBean>
+                                <library>webclient</library>
+                                <useJakartaEe>true</useJakartaEe>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/scrapper/pom.xml
+++ b/scrapper/pom.xml
@@ -181,15 +181,14 @@
                             <inputSpec>${project.basedir}/../bot/src/main/resources/api.json</inputSpec>
                             <generatorName>java</generatorName>
                             <packageName>edu.java.scrapper.clients.common.openapi</packageName>
-                            <apiPackage>edu.java.scrapper.clients.scrapper</apiPackage>
-                            <modelPackage>edu.java.scrapper.clients.scrapper.model</modelPackage>
+                            <apiPackage>edu.java.scrapper.clients.bot</apiPackage>
+                            <modelPackage>edu.java.scrapper.clients.bot.model</modelPackage>
                             <invokerPackage>edu.java.scrapper.clients.common.openapi.invoker</invokerPackage>
                             <generateModelTests>false</generateModelTests>
                             <generateModelDocumentation>false</generateModelDocumentation>
                             <generateApiTests>false</generateApiTests>
                             <generateApiDocumentation>false</generateApiDocumentation>
                             <configOptions>
-                                <generateClientAsBean>true</generateClientAsBean>
                                 <library>webclient</library>
                                 <useJakartaEe>true</useJakartaEe>
                             </configOptions>

--- a/scrapper/src/main/java/edu/java/scrapper/clients/bot/BotClientConfiguration.java
+++ b/scrapper/src/main/java/edu/java/scrapper/clients/bot/BotClientConfiguration.java
@@ -1,0 +1,19 @@
+package edu.java.scrapper.clients.bot;
+
+import edu.java.scrapper.clients.common.openapi.invoker.ApiClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BotClientConfiguration {
+    @Value("#{@applicationConfig.clients.bot.baseUrl}")
+    public String baseUrl;
+
+    @Bean
+    public DefaultApi botClient() {
+        ApiClient apiClient = new ApiClient();
+        apiClient.setBasePath(baseUrl);
+        return new DefaultApi(apiClient);
+    }
+}

--- a/scrapper/src/main/java/edu/java/scrapper/clients/bot/BotClientConfiguration.java
+++ b/scrapper/src/main/java/edu/java/scrapper/clients/bot/BotClientConfiguration.java
@@ -11,9 +11,9 @@ public class BotClientConfiguration {
     public String baseUrl;
 
     @Bean
-    public DefaultApi botClient() {
+    public BotApi botClient() {
         ApiClient apiClient = new ApiClient();
         apiClient.setBasePath(baseUrl);
-        return new DefaultApi(apiClient);
+        return new BotApi(apiClient);
     }
 }

--- a/scrapper/src/main/java/edu/java/scrapper/configuration/ApplicationConfig.java
+++ b/scrapper/src/main/java/edu/java/scrapper/configuration/ApplicationConfig.java
@@ -2,11 +2,11 @@ package edu.java.scrapper.configuration;
 
 import jakarta.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
 @Validated
-@Configuration
+@Component
 @ConfigurationProperties(prefix = "app", ignoreUnknownFields = false)
 public class ApplicationConfig {
     @NotNull

--- a/scrapper/src/main/java/edu/java/scrapper/configuration/ApplicationConfig.java
+++ b/scrapper/src/main/java/edu/java/scrapper/configuration/ApplicationConfig.java
@@ -10,16 +10,16 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "app", ignoreUnknownFields = false)
 public class ApplicationConfig {
     @NotNull
-    public Scheduler scheduler;
+    Scheduler scheduler;
 
     @NotNull
-    public Clients clients = new Clients();
+    Clients clients = new Clients();
 
     public Scheduler getScheduler() {
         return scheduler;
     }
 
-    public void setScheduler(Scheduler scheduler) {
+    void setScheduler(Scheduler scheduler) {
         this.scheduler = scheduler;
     }
 
@@ -27,7 +27,7 @@ public class ApplicationConfig {
         return clients;
     }
 
-    public void setClients(Clients clients) {
+    void setClients(Clients clients) {
         this.clients = clients;
     }
 }

--- a/scrapper/src/main/java/edu/java/scrapper/configuration/BotClient.java
+++ b/scrapper/src/main/java/edu/java/scrapper/configuration/BotClient.java
@@ -1,13 +1,13 @@
 package edu.java.scrapper.configuration;
 
 public class BotClient {
-    public String baseUrl = "http://localhost:8090/";
+    String baseUrl = "http://localhost:8090/";
 
     public String getBaseUrl() {
         return baseUrl;
     }
 
-    public void setBaseUrl(String baseUrl) {
+    void setBaseUrl(String baseUrl) {
         this.baseUrl = baseUrl;
     }
 }

--- a/scrapper/src/main/java/edu/java/scrapper/configuration/BotClient.java
+++ b/scrapper/src/main/java/edu/java/scrapper/configuration/BotClient.java
@@ -1,0 +1,13 @@
+package edu.java.scrapper.configuration;
+
+public class BotClient {
+    public String baseUrl = "http://localhost:8090/";
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+}

--- a/scrapper/src/main/java/edu/java/scrapper/configuration/Clients.java
+++ b/scrapper/src/main/java/edu/java/scrapper/configuration/Clients.java
@@ -1,6 +1,7 @@
 package edu.java.scrapper.configuration;
 
 public class Clients {
+    public BotClient bot = new BotClient();
     public GithubClient github = new GithubClient();
     public StackOverflowClient stackoverflow = new StackOverflowClient();
 
@@ -18,5 +19,13 @@ public class Clients {
 
     public void setStackoverflow(StackOverflowClient stackoverflow) {
         this.stackoverflow = stackoverflow;
+    }
+
+    public BotClient getBot() {
+        return bot;
+    }
+
+    public void setBot(BotClient bot) {
+        this.bot = bot;
     }
 }

--- a/scrapper/src/main/java/edu/java/scrapper/configuration/Clients.java
+++ b/scrapper/src/main/java/edu/java/scrapper/configuration/Clients.java
@@ -1,15 +1,15 @@
 package edu.java.scrapper.configuration;
 
 public class Clients {
-    public BotClient bot = new BotClient();
-    public GithubClient github = new GithubClient();
-    public StackOverflowClient stackoverflow = new StackOverflowClient();
+    BotClient bot = new BotClient();
+    GithubClient github = new GithubClient();
+    StackOverflowClient stackoverflow = new StackOverflowClient();
 
     public GithubClient getGithub() {
         return github;
     }
 
-    public void setGithub(GithubClient github) {
+    void setGithub(GithubClient github) {
         this.github = github;
     }
 
@@ -17,7 +17,7 @@ public class Clients {
         return stackoverflow;
     }
 
-    public void setStackoverflow(StackOverflowClient stackoverflow) {
+    void setStackoverflow(StackOverflowClient stackoverflow) {
         this.stackoverflow = stackoverflow;
     }
 
@@ -25,7 +25,7 @@ public class Clients {
         return bot;
     }
 
-    public void setBot(BotClient bot) {
+    void setBot(BotClient bot) {
         this.bot = bot;
     }
 }

--- a/scrapper/src/main/java/edu/java/scrapper/configuration/GithubClient.java
+++ b/scrapper/src/main/java/edu/java/scrapper/configuration/GithubClient.java
@@ -1,13 +1,13 @@
 package edu.java.scrapper.configuration;
 
 public class GithubClient {
-    public String baseUrl = "https://api.github.com/";
+    String baseUrl = "https://api.github.com/";
 
     public String getBaseUrl() {
         return baseUrl;
     }
 
-    public void setBaseUrl(String baseUrl) {
+    void setBaseUrl(String baseUrl) {
         this.baseUrl = baseUrl;
     }
 }

--- a/scrapper/src/main/java/edu/java/scrapper/configuration/StackOverflowClient.java
+++ b/scrapper/src/main/java/edu/java/scrapper/configuration/StackOverflowClient.java
@@ -1,14 +1,14 @@
 package edu.java.scrapper.configuration;
 
 public class StackOverflowClient {
-    public String baseUrl = "https://api.stackexchange.com/2.3";
-    public String filter = "!BByLnZ1QNx_zLScMFi.8Pz6HIwMox1_ImiqaT5V1oBML_rwYaA-OOGYnkF0NLH*5-jYC--cO4ynL";
+    String baseUrl = "https://api.stackexchange.com/2.3";
+    String filter = "!BByLnZ1QNx_zLScMFi.8Pz6HIwMox1_ImiqaT5V1oBML_rwYaA-OOGYnkF0NLH*5-jYC--cO4ynL";
 
     public String getBaseUrl() {
         return baseUrl;
     }
 
-    public void setBaseUrl(String baseUrl) {
+    void setBaseUrl(String baseUrl) {
         this.baseUrl = baseUrl;
     }
 
@@ -16,7 +16,7 @@ public class StackOverflowClient {
         return filter;
     }
 
-    public void setFilter(String filter) {
+    void setFilter(String filter) {
         this.filter = filter;
     }
 }

--- a/scrapper/src/main/java/edu/java/scrapper/controllers/LinksApiController.java
+++ b/scrapper/src/main/java/edu/java/scrapper/controllers/LinksApiController.java
@@ -1,0 +1,31 @@
+package edu.java.scrapper.controllers;
+
+import edu.java.scrapper.controllers.model.AddLinkRequest;
+import edu.java.scrapper.controllers.model.LinkResponse;
+import edu.java.scrapper.controllers.model.ListLinksResponse;
+import edu.java.scrapper.controllers.model.RemoveLinkRequest;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Log4j2
+public class LinksApiController implements LinksApi {
+    @Override
+    public ResponseEntity<LinkResponse> linksDelete(final Long tgChatId, final RemoveLinkRequest removeLinkRequest) {
+        log.trace("linksDelete: " + tgChatId + " " + removeLinkRequest);
+        return LinksApi.super.linksDelete(tgChatId, removeLinkRequest);
+    }
+
+    @Override
+    public ResponseEntity<ListLinksResponse> linksGet(final Long tgChatId) {
+        log.trace("linksGet: " + tgChatId);
+        return LinksApi.super.linksGet(tgChatId);
+    }
+
+    @Override
+    public ResponseEntity<LinkResponse> linksPost(final Long tgChatId, final AddLinkRequest addLinkRequest) {
+        log.trace("linksPost: " + tgChatId + " " + addLinkRequest);
+        return LinksApi.super.linksPost(tgChatId, addLinkRequest);
+    }
+}

--- a/scrapper/src/main/java/edu/java/scrapper/controllers/RestExceptionHandler.java
+++ b/scrapper/src/main/java/edu/java/scrapper/controllers/RestExceptionHandler.java
@@ -1,0 +1,65 @@
+package edu.java.scrapper.controllers;
+
+import edu.java.scrapper.controllers.model.ApiErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Arrays;
+
+@RestControllerAdvice
+public class RestExceptionHandler {
+    @ExceptionHandler
+    public ResponseEntity<ApiErrorResponse> handleException(Exception e) {
+        ApiErrorResponse response = new ApiErrorResponse();
+
+        if (e instanceof ErrorResponse errorResponse) {
+            fillResponseFromErrorResponse(response, errorResponse);
+        }
+        fillResponseFromException(response, e);
+
+        HttpStatus responseCode;
+        try {
+            responseCode = HttpStatus.valueOf(Integer.parseInt(response.getCode()));
+        } catch (IllegalArgumentException exception) {
+            responseCode = HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        return new ResponseEntity<>(response, responseCode);
+    }
+
+    public static void fillResponseFromErrorResponse(ApiErrorResponse response, ErrorResponse e) {
+        if (response.getCode() == null) {
+            response.setCode(Integer.toString(e.getBody().getStatus()));
+        }
+        if (response.getDescription() == null) {
+            response.setDescription(e.getBody().getDetail());
+        }
+    }
+
+    public static void fillResponseFromException(ApiErrorResponse response, Exception e) {
+        if (response.getCode() == null) {
+            if (e instanceof HttpMessageNotReadableException) {
+                response.setCode("400");
+            } else {
+                response.setCode("500");
+            }
+        }
+        if (response.getExceptionName() == null) {
+            response.setExceptionName(e.getClass().getSimpleName());
+        }
+        if (response.getExceptionMessage() == null) {
+            response.setExceptionMessage(e.getMessage());
+        }
+        if (response.getDescription() == null) {
+            response.setDescription(e.toString());
+        }
+        if (response.getStacktrace() == null) {
+            response.setStacktrace(
+                Arrays.stream(e.getStackTrace()).map(StackTraceElement::toString).toList()
+            );
+        }
+    }
+}

--- a/scrapper/src/main/java/edu/java/scrapper/controllers/RestExceptionHandler.java
+++ b/scrapper/src/main/java/edu/java/scrapper/controllers/RestExceptionHandler.java
@@ -1,14 +1,13 @@
 package edu.java.scrapper.controllers;
 
 import edu.java.scrapper.controllers.model.ApiErrorResponse;
+import java.util.Arrays;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.util.Arrays;
 
 @RestControllerAdvice
 public class RestExceptionHandler {

--- a/scrapper/src/main/java/edu/java/scrapper/controllers/TgChatApiController.java
+++ b/scrapper/src/main/java/edu/java/scrapper/controllers/TgChatApiController.java
@@ -1,0 +1,21 @@
+package edu.java.scrapper.controllers;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Log4j2
+public class TgChatApiController implements TgChatApi {
+    @Override
+    public ResponseEntity<Void> tgChatIdDelete(final Long id) {
+        log.trace("tgChatIdDelete: " + id);
+        return TgChatApi.super.tgChatIdDelete(id);
+    }
+
+    @Override
+    public ResponseEntity<Void> tgChatIdPost(final Long id) {
+        log.trace("tgChatIdPost: " + id);
+        return TgChatApi.super.tgChatIdPost(id);
+    }
+}

--- a/scrapper/src/main/resources/api.json
+++ b/scrapper/src/main/resources/api.json
@@ -1,0 +1,296 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Scrapper API",
+        "version": "1.0.0",
+        "contact": {
+            "name": "Alexander Biryukov",
+            "url": "https://github.com"
+        }
+    },
+    "paths": {
+        "/tg-chat/{id}": {
+            "post": {
+                "summary": "Зарегистрировать чат",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Чат зарегистрирован"
+                    },
+                    "400": {
+                        "description": "Некорректные параметры запроса",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Удалить чат",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Чат успешно удалён"
+                    },
+                    "400": {
+                        "description": "Некорректные параметры запроса",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Чат не существует",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/links": {
+            "get": {
+                "summary": "Получить все отслеживаемые ссылки",
+                "parameters": [
+                    {
+                        "name": "Tg-Chat-Id",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Ссылки успешно получены",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ListLinksResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Некорректные параметры запроса",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "summary": "Добавить отслеживание ссылки",
+                "parameters": [
+                    {
+                        "name": "Tg-Chat-Id",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AddLinkRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Ссылка успешно добавлена",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LinkResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Некорректные параметры запроса",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Убрать отслеживание ссылки",
+                "parameters": [
+                    {
+                        "name": "Tg-Chat-Id",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RemoveLinkRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Ссылка успешно убрана",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LinkResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Некорректные параметры запроса",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Ссылка не найдена",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "LinkResponse": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "url": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                }
+            },
+            "ApiErrorResponse": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "code": {
+                        "type": "string"
+                    },
+                    "exceptionName": {
+                        "type": "string"
+                    },
+                    "exceptionMessage": {
+                        "type": "string"
+                    },
+                    "stacktrace": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "AddLinkRequest": {
+                "type": "object",
+                "properties": {
+                    "link": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                }
+            },
+            "ListLinksResponse": {
+                "type": "object",
+                "properties": {
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/LinkResponse"
+                        }
+                    },
+                    "size": {
+                        "type": "integer",
+                        "format": "int32"
+                    }
+                }
+            },
+            "RemoveLinkRequest": {
+                "type": "object",
+                "properties": {
+                    "link": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/scrapper/src/main/resources/api.json
+++ b/scrapper/src/main/resources/api.json
@@ -246,7 +246,11 @@
                         "type": "string",
                         "format": "uri"
                     }
-                }
+                },
+                "required": [
+                    "id",
+                    "url"
+                ]
             },
             "ApiErrorResponse": {
                 "type": "object",
@@ -269,7 +273,11 @@
                             "type": "string"
                         }
                     }
-                }
+                },
+                "required": [
+                    "code",
+                    "description"
+                ]
             },
             "AddLinkRequest": {
                 "type": "object",
@@ -278,7 +286,10 @@
                         "type": "string",
                         "format": "uri"
                     }
-                }
+                },
+                "required": [
+                    "link"
+                ]
             },
             "ListLinksResponse": {
                 "type": "object",
@@ -293,7 +304,10 @@
                         "type": "integer",
                         "format": "int32"
                     }
-                }
+                },
+                "required": [
+                    "links"
+                ]
             },
             "RemoveLinkRequest": {
                 "type": "object",
@@ -302,7 +316,10 @@
                         "type": "string",
                         "format": "uri"
                     }
-                }
+                },
+                "required": [
+                    "link"
+                ]
             }
         }
     }

--- a/scrapper/src/main/resources/api.json
+++ b/scrapper/src/main/resources/api.json
@@ -11,6 +11,7 @@
     "paths": {
         "/tg-chat/{id}": {
             "post": {
+                "tags": [ "scrapper", "tg" ],
                 "summary": "Зарегистрировать чат",
                 "parameters": [
                     {
@@ -43,6 +44,7 @@
                 }
             },
             "delete": {
+                "tags": [ "scrapper", "tg" ],
                 "summary": "Удалить чат",
                 "parameters": [
                     {
@@ -84,6 +86,7 @@
         },
         "/links": {
             "get": {
+                "tags": [ "scrapper", "links" ],
                 "summary": "Получить все отслеживаемые ссылки",
                 "parameters": [
                     {
@@ -120,6 +123,7 @@
                 }
             },
             "post": {
+                "tags": [ "scrapper", "links" ],
                 "summary": "Добавить отслеживание ссылки",
                 "parameters": [
                     {
@@ -176,6 +180,7 @@
                 }
             },
             "delete": {
+                "tags": [ "scrapper", "links" ],
                 "summary": "Убрать отслеживание ссылки",
                 "parameters": [
                     {

--- a/scrapper/src/main/resources/api.json
+++ b/scrapper/src/main/resources/api.json
@@ -25,7 +25,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Чат зарегистрирован"
+                        "description": "Чат уже был зарегистрирован"
+                    },
+                    "201": {
+                        "description": "Чат успешно зарегистрирован"
                     },
                     "400": {
                         "description": "Некорректные параметры запроса",
@@ -141,6 +144,16 @@
                 },
                 "responses": {
                     "200": {
+                        "description": "Ссылка уже была добавлена",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LinkResponse"
+                                }
+                            }
+                        }
+                    },
+                    "201": {
                         "description": "Ссылка успешно добавлена",
                         "content": {
                             "application/json": {

--- a/scrapper/src/main/resources/application.yml
+++ b/scrapper/src/main/resources/application.yml
@@ -17,3 +17,7 @@ server:
 
 logging:
   config: classpath:log4j2-plain.xml
+
+springdoc:
+  swagger-ui:
+    path: "/swagger-ui"

--- a/scrapper/src/test/java/edu/java/scrapper/RestExceptionHandlerTest.java
+++ b/scrapper/src/test/java/edu/java/scrapper/RestExceptionHandlerTest.java
@@ -1,0 +1,90 @@
+package edu.java.scrapper;
+
+import edu.java.scrapper.controllers.model.ApiErrorResponse;
+import java.net.URI;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class RestExceptionHandlerTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    @Test
+    void testUnknownEndpoint() {
+        ResponseEntity<ApiErrorResponse> response =
+            restTemplate.getForEntity(URI.create("http://localhost:" + port + "/"), ApiErrorResponse.class);
+
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        Assertions.assertEquals(HttpStatus.NOT_FOUND.value(), Integer.valueOf(response.getBody().getCode()));
+    }
+
+    @Test
+    void testMethodNotSupported() {
+        ResponseEntity<ApiErrorResponse> response =
+            restTemplate.getForEntity(URI.create("http://localhost:" + port + "/tg-chat/123"), ApiErrorResponse.class);
+
+        Assertions.assertEquals(HttpStatus.METHOD_NOT_ALLOWED, response.getStatusCode());
+        Assertions.assertEquals(HttpStatus.METHOD_NOT_ALLOWED.value(), Integer.valueOf(response.getBody().getCode()));
+    }
+
+    @Test
+    void testNoPayload() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> entity = new HttpEntity<>("", headers);
+
+        ResponseEntity<ApiErrorResponse> response = restTemplate.exchange(
+            URI.create("http://localhost:" + port + "/links"),
+            HttpMethod.POST,
+            entity,
+            ApiErrorResponse.class
+        );
+
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        Assertions.assertEquals(
+            HttpStatus.BAD_REQUEST.value(),
+            Integer.valueOf(response.getBody().getCode())
+        );
+        Assertions.assertTrue(response.getBody().getDescription().contains("Required header"));
+    }
+
+    @Test
+    void testInvalidPayload() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add("Tg-Chat-Id", "123");
+        HttpEntity<String> entity = new HttpEntity<>(
+            """
+            {
+            }
+            """,
+            headers
+        );
+
+        ResponseEntity<ApiErrorResponse> response = restTemplate.exchange(
+            URI.create("http://localhost:" + port + "/links"),
+            HttpMethod.POST,
+            entity,
+            ApiErrorResponse.class
+        );
+
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST.value(), Integer.valueOf(response.getBody().getCode()));
+        Assertions.assertTrue(response.getBody().getDescription().contains("Invalid request content"));
+    }
+}


### PR DESCRIPTION
2.10 ДЗ 3

---

И клиентов, и контроллеры генерирую на основе спецификации с использованием openapi generator и соответствующего плагина для maven.

> #дз3 нам можно использовать кодогенерацию на основе OpenAPI или всё обязательно самим писать?

> Оба варианта подходят

https://t.me/c/2056008600/1990

 Генерируемый код не тестирую специально - он и так должен быть приличный, всё же инструмент распространенный

И коммитить генерируемый код не стал - он генерируется при +- каждой сборке (при наличии изменений), я его не редактирую

---

http://localhost:8080/swagger-ui (и 8090) отвечают и работают.

---

Обработчик ошибок получился странный: он одинаковый в scrapper-е и в bot-е, но тупо использовать один и тот же класс нельзя - так как моделька `ApiErrorResponse` генерируется в разные пакеты - по сути единственное различие.
С одной стороны - получается паста. А с другой - это разные микросервисы, им вполне логично иметь свои собственные компоненты, в т.ч. обработку ошибок. А увеличивать связность - нехорошо (?)

С тестами не уверен что всё правильно получилось: использую специально предназначенный класс `TestRestTemplate`, чтобы отправлять запросы, не соответствующие спецификации. Но он `...RestTemplate`, который запрещен к использованию для создания клиентов (кстати, почему?)

---

Нужно было доработать API для обработки ситуаций, в которых добавляют ресурс (чат или ссылку) повторно. Согласно моим взглядам на мир - это не ошибка, поэтому хочется возвращать 2xx. Но подходящий 200 уже был занят под успешное добавление - заменил его на более специфичный `201 Created`, а в случае повторного добавления возвращаю `200 OK`. То есть, получилась не доработка, а изменение.

Ещё на тему API: по спецификации в случае некорректного запроса возвращается `400 Bad Request`. Однако некорректных запросов бывает много разных, в том числе подходящие под более специфичные коды: `405 Method Not Allowed`, `415 Unsupported Media Type`. В моей реализации возможна отправка и ответов с такими кодами, чтобы предоставить получателю более подробный статус. Но, это не соответствует спецификации.
Но так ли страшно несоответствие спецификации в области обработки ошибок? Например, сервер может в любой момент вернуть всякое `5xx Internal Server Error`, даже если это не указано в спецификации. Или же на самом деле даже 500 вернуть нельзя, не указав это в спеке?